### PR TITLE
feat: add Tempo testnet support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,7 @@ ethereum_sepolia ="${RPC_ETHEREUM_SEPOLIA}"
 optimism_sepolia = "${RPC_OPTIMISM_SEPOLIA}"
 polygon_mumbai = "${RPC_POLYGON_MUMBAI}"
 base_sepolia = "${RPC_BASE_SEPOLIA}"
+tempo_testnet = "${RPC_TEMPO_TESTNET}"
 
 [profile.ci_sizes]
 optimizer_runs = 500 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -26,7 +26,8 @@ contract Deploy is Script, Sphinx {
         // TODO: Update to contain JB Emergency Developers
         sphinxConfig.projectName = "nana-omnichain-deployers-v5";
         sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum"];
-        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia"];
+        sphinxConfig.testnets =
+            ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia", "tempo_testnet"];
     }
 
     function run() public {


### PR DESCRIPTION
## Summary
- Add Tempo testnet RPC endpoint to `foundry.toml`
- Include `tempo_testnet` in Sphinx testnets deployment configuration

## Context
Tempo is an L1 blockchain where the native token is USD (not ETH). This PR adds the deployment config needed to deploy omnichain deployer contracts to Tempo testnet.

Part of the cross-repo Tempo integration:
- Bananapus/nana-core-v5 (deployment config)
- Bananapus/nana-suckers-v5 (CCIP constants, sucker deployers, security tests)
- rev-net/revnet-core-v5 (sucker deployer config, security tests)

## Test plan
- [ ] Verify Sphinx recognizes `tempo_testnet` as a valid deployment target
- [ ] Verify RPC endpoint resolves correctly when `RPC_TEMPO_TESTNET` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)