### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,7 +11,7 @@ import "@bananapus/721-hook-v5/script/helpers/Hook721DeploymentLib.sol";
 import "src/JBOmnichainDeployer.sol";
 
 contract Deploy is Script, Sphinx {
-    bytes32 constant NANA_OMNICHAIN_DEPLOYER_SALT = "JBOmnichainDeployer_";
+    bytes32 constant NANA_OMNICHAIN_DEPLOYER_SALT = "JBOmnichainDeployerV6_";
 
     /// @notice tracks the deployment of the core contracts for the chain we are deploying to.
     CoreDeployment core;

--- a/script/Deploy5_1.s.sol
+++ b/script/Deploy5_1.s.sol
@@ -11,7 +11,7 @@ import "@bananapus/721-hook-v5/script/helpers/Hook721DeploymentLib.sol";
 import "src/JBOmnichainDeployer.sol";
 
 contract Deploy is Script, Sphinx {
-    bytes32 constant NANA_OMNICHAIN_DEPLOYER_SALT = "JBOmnichainDeployer_";
+    bytes32 constant NANA_OMNICHAIN_DEPLOYER_SALT = "JBOmnichainDeployerV6_";
 
     /// @notice tracks the deployment of the core contracts for the chain we are deploying to.
     CoreDeployment core;


### PR DESCRIPTION
## Summary
- Updated `NANA_OMNICHAIN_DEPLOYER_SALT` from `JBOmnichainDeployer_` to `JBOmnichainDeployerV6_` in both `Deploy.s.sol` and `Deploy5_1.s.sol`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)