### PR TITLE
chore: v6 QC pass

### DIFF
--- a/src/JBOmnichainDeployer.sol
+++ b/src/JBOmnichainDeployer.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.23;
 
 import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {IJB721TiersHook} from "@bananapus/721-hook-v5/src/interfaces/IJB721TiersHook.sol";
 import {IJB721TiersHookDeployer} from "@bananapus/721-hook-v5/src/interfaces/IJB721TiersHookProjectDeployer.sol";
@@ -52,6 +53,9 @@ contract JBOmnichainDeployer is
     /// @notice Thrown when a data hook is set to this contract.
     error JBOmnichainDeployer_InvalidHook();
 
+    /// @notice Thrown when the contract receives an NFT that is not from the `JBProjects` contract.
+    error JBOmnichainDeployer_UnexpectedNFT();
+
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
     //*********************************************************************//
@@ -66,7 +70,7 @@ contract JBOmnichainDeployer is
     IJBSuckerRegistry public immutable SUCKER_REGISTRY;
 
     //*********************************************************************//
-    // --------------------- public stored properties -------------------- //
+    // -------------------- internal stored properties ------------------- //
     //*********************************************************************//
 
     /// @notice Each project's data hook provided on deployment.
@@ -176,7 +180,7 @@ contract JBOmnichainDeployer is
     /// @custom:param projectId The ID of the project to get the data hook for.
     /// @custom:param rulesetId The ID of the ruleset to get the data hook for.
     /// @return useDataHookForPay Whether the data hook is used for pay.
-    /// @return useDataHookForCashout Whether the data hook is used for cashout.
+    /// @return useDataHookForCashOut Whether the data hook is used for cash out.
     /// @return dataHook The data hook.
     function dataHookOf(
         uint256 projectId,
@@ -185,7 +189,7 @@ contract JBOmnichainDeployer is
         external
         view
         override
-        returns (bool useDataHookForPay, bool useDataHookForCashout, IJBRulesetDataHook dataHook)
+        returns (bool useDataHookForPay, bool useDataHookForCashOut, IJBRulesetDataHook dataHook)
     {
         JBDeployerHookConfig memory hook = _dataHookOf[projectId][rulesetId];
         return (hook.useDataHookForPay, hook.useDataHookForCashOut, hook.dataHook);
@@ -233,7 +237,8 @@ contract JBOmnichainDeployer is
     /// @return A flag indicating if the provided interface ID is supported.
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IJBOmnichainDeployer).interfaceId
-            || interfaceId == type(IJBRulesetDataHook).interfaceId || interfaceId == type(IERC721Receiver).interfaceId;
+            || interfaceId == type(IJBRulesetDataHook).interfaceId || interfaceId == type(IERC721Receiver).interfaceId
+            || interfaceId == type(IERC165).interfaceId;
     }
 
     //*********************************************************************//
@@ -335,6 +340,7 @@ contract JBOmnichainDeployer is
     /// @param launchProjectConfig Configuration which dictates the behavior of the project which is being launched.
     /// @param salt A salt to use for the deterministic deployment.
     /// @param suckerDeploymentConfiguration The suckers to set up for the project. Suckers facilitate cross-chain
+    /// token transfers between peer projects on different networks.
     /// @param controller The controller to use for launching the project.
     /// @return projectId The ID of the newly launched project.
     /// @return hook The 721 tiers hook that was deployed for the project.
@@ -361,7 +367,7 @@ contract JBOmnichainDeployer is
         });
 
         // Convert the 721 ruleset configurations to regular ruleset configurations.
-        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasouce.
+        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasource.
         JBRulesetConfig[] memory rulesetConfigurations = _setup({
             projectId: projectId,
             rulesetConfigurations: _from721Config(launchProjectConfig.rulesetConfigurations, hook)
@@ -480,7 +486,7 @@ contract JBOmnichainDeployer is
         JBOwnable(address(hook)).transferOwnershipToProject(projectId);
 
         // Convert the 721 ruleset configurations to regular ruleset configurations.
-        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasouce.
+        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasource.
         JBRulesetConfig[] memory rulesetConfigurations = _setup({
             projectId: projectId,
             rulesetConfigurations: _from721Config(launchRulesetsConfig.rulesetConfigurations, hook)
@@ -559,7 +565,7 @@ contract JBOmnichainDeployer is
         });
 
         // Convert the 721 ruleset configurations to regular ruleset configurations.
-        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasouce.
+        // Then modify the ruleset configurations to use this deployer as a wrapper for the datasource.
         JBRulesetConfig[] memory rulesetConfigurations = _setup({
             projectId: projectId,
             rulesetConfigurations: _from721Config(queueRulesetsConfig.rulesetConfigurations, hook)
@@ -576,7 +582,7 @@ contract JBOmnichainDeployer is
     /// @dev Make sure this contract can only receive project NFTs from `JBProjects`.
     function onERC721Received(address, address, uint256, bytes calldata) external view returns (bytes4) {
         // Make sure the 721 received is from the `JBProjects` contract.
-        if (msg.sender != address(PROJECTS)) revert();
+        if (msg.sender != address(PROJECTS)) revert JBOmnichainDeployer_UnexpectedNFT();
 
         return IERC721Receiver.onERC721Received.selector;
     }

--- a/src/interfaces/IJBOmnichainDeployer.sol
+++ b/src/interfaces/IJBOmnichainDeployer.sol
@@ -14,14 +14,24 @@ import {JBDeployerHookConfig} from "../structs/JBDeployerHookConfig.sol";
 import {JBSuckerDeploymentConfig} from "../structs/JBSuckerDeploymentConfig.sol";
 
 interface IJBOmnichainDeployer {
+    /// @notice Get the data hook for a project and ruleset.
+    /// @param projectId The ID of the project to get the data hook for.
+    /// @param rulesetId The ID of the ruleset to get the data hook for.
+    /// @return useDataHookForPay Whether the data hook is used for pay.
+    /// @return useDataHookForCashOut Whether the data hook is used for cash out.
+    /// @return dataHook The data hook.
     function dataHookOf(
         uint256 projectId,
         uint256 rulesetId
     )
         external
         view
-        returns (bool useDataHookForPay, bool useDataHookForCashout, IJBRulesetDataHook dataHook);
+        returns (bool useDataHookForPay, bool useDataHookForCashOut, IJBRulesetDataHook dataHook);
 
+    /// @notice Deploy new suckers for an existing project.
+    /// @param projectId The ID of the project to deploy suckers for.
+    /// @param suckerDeploymentConfiguration The suckers to set up for the project.
+    /// @return suckers The addresses of the deployed suckers.
     function deploySuckersFor(
         uint256 projectId,
         JBSuckerDeploymentConfig calldata suckerDeploymentConfiguration
@@ -29,10 +39,21 @@ interface IJBOmnichainDeployer {
         external
         returns (address[] memory suckers);
 
+    /// @notice Creates a project with suckers.
+    /// @param owner The project's owner. The project ERC-721 will be minted to this address.
+    /// @param projectUri The project's metadata URI.
+    /// @param rulesetConfigurations The rulesets to queue.
+    /// @param terminalConfigurations The terminals to set up for the project.
+    /// @param memo A memo to pass along to the emitted event.
+    /// @param suckerDeploymentConfiguration The suckers to set up for the project. Suckers facilitate cross-chain
+    /// token transfers between peer projects on different networks.
+    /// @param controller The controller to use for launching the project.
+    /// @return projectId The project's ID.
+    /// @return suckers The addresses of the deployed suckers.
     function launchProjectFor(
         address owner,
         string calldata projectUri,
-        JBRulesetConfig[] calldata rulesetConfigurations,
+        JBRulesetConfig[] memory rulesetConfigurations,
         JBTerminalConfig[] calldata terminalConfigurations,
         string calldata memo,
         JBSuckerDeploymentConfig calldata suckerDeploymentConfiguration,
@@ -41,6 +62,17 @@ interface IJBOmnichainDeployer {
         external
         returns (uint256 projectId, address[] memory suckers);
 
+    /// @notice Launches a new project with a 721 tiers hook attached, and with suckers.
+    /// @param owner The address to set as the owner of the project.
+    /// @param deployTiersHookConfig Configuration which dictates the behavior of the 721 tiers hook.
+    /// @param launchProjectConfig Configuration which dictates the behavior of the project.
+    /// @param salt A salt to use for the deterministic deployment.
+    /// @param suckerDeploymentConfiguration The suckers to set up for the project. Suckers facilitate cross-chain
+    /// token transfers between peer projects on different networks.
+    /// @param controller The controller to use for launching the project.
+    /// @return projectId The ID of the newly launched project.
+    /// @return hook The 721 tiers hook that was deployed for the project.
+    /// @return suckers The addresses of the deployed suckers.
     function launch721ProjectFor(
         address owner,
         JBDeploy721TiersHookConfig calldata deployTiersHookConfig,
@@ -52,16 +84,31 @@ interface IJBOmnichainDeployer {
         external
         returns (uint256 projectId, IJB721TiersHook hook, address[] memory suckers);
 
+    /// @notice Launches new rulesets for a project, using this contract as the data hook.
+    /// @param projectId The ID of the project to launch the rulesets for.
+    /// @param rulesetConfigurations The rulesets to launch.
+    /// @param terminalConfigurations The terminals to set up for the project.
+    /// @param memo A memo to pass along to the emitted event.
+    /// @param controller The controller to use for launching the rulesets.
+    /// @return rulesetId The ID of the newly launched rulesets.
     function launchRulesetsFor(
         uint256 projectId,
         JBRulesetConfig[] calldata rulesetConfigurations,
-        JBTerminalConfig[] memory terminalConfigurations,
+        JBTerminalConfig[] calldata terminalConfigurations,
         string calldata memo,
         IJBController controller
     )
         external
         returns (uint256 rulesetId);
 
+    /// @notice Launches new rulesets for a project with a 721 tiers hook attached.
+    /// @param projectId The ID of the project to launch the rulesets for.
+    /// @param deployTiersHookConfig Configuration which dictates the behavior of the 721 tiers hook.
+    /// @param launchRulesetsConfig Configuration which dictates the behavior of the rulesets.
+    /// @param controller The controller to use for launching the rulesets.
+    /// @param salt A salt to use for the deterministic deployment.
+    /// @return rulesetId The ID of the newly launched rulesets.
+    /// @return hook The 721 tiers hook that was deployed for the project.
     function launch721RulesetsFor(
         uint256 projectId,
         JBDeploy721TiersHookConfig memory deployTiersHookConfig,
@@ -72,6 +119,12 @@ interface IJBOmnichainDeployer {
         external
         returns (uint256 rulesetId, IJB721TiersHook hook);
 
+    /// @notice Queues new rulesets for a project, using this contract as the data hook.
+    /// @param projectId The ID of the project to queue the rulesets for.
+    /// @param rulesetConfigurations The rulesets to queue.
+    /// @param memo A memo to pass along to the emitted event.
+    /// @param controller The controller to use for queuing the rulesets.
+    /// @return rulesetId The ID of the newly queued rulesets.
     function queueRulesetsOf(
         uint256 projectId,
         JBRulesetConfig[] calldata rulesetConfigurations,
@@ -81,10 +134,18 @@ interface IJBOmnichainDeployer {
         external
         returns (uint256 rulesetId);
 
+    /// @notice Queues new rulesets for a project with a 721 tiers hook attached.
+    /// @param projectId The ID of the project to queue the rulesets for.
+    /// @param deployTiersHookConfig Configuration which dictates the behavior of the 721 tiers hook.
+    /// @param queueRulesetsConfig Configuration which dictates the behavior of the rulesets.
+    /// @param controller The controller to use for queuing the rulesets.
+    /// @param salt A salt to use for the deterministic deployment.
+    /// @return rulesetId The ID of the newly queued rulesets.
+    /// @return hook The 721 tiers hook that was deployed for the project.
     function queue721RulesetsOf(
         uint256 projectId,
         JBDeploy721TiersHookConfig memory deployTiersHookConfig,
-        JBQueueRulesetsConfig memory queueRulesetsConfig,
+        JBQueueRulesetsConfig calldata queueRulesetsConfig,
         IJBController controller,
         bytes32 salt
     )


### PR DESCRIPTION
## Summary
- Fix `useDataHookForCashout` to `useDataHookForCashOut` (capital O) in interface and implementation
- Fix 3 data location mismatches between interface and implementation: `launchProjectFor` (calldata->memory), `launchRulesetsFor` (memory->calldata), `queue721RulesetsOf` (memory->calldata)
- Add return variable names where interface was missing them
- Fix `_dataHookOf` section header from "public stored properties" to "internal stored properties"
- Fix "datasouce" typo to "datasource" (3 occurrences)
- Complete truncated `@param suckerDeploymentConfiguration` NatSpec on `launch721ProjectFor`
- Add `IERC165` to `supportsInterface` check
- Replace bare `revert()` in `onERC721Received` with custom error `JBOmnichainDeployer_UnexpectedNFT()`
- Add full NatSpec to all functions in `IJBOmnichainDeployer.sol`

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm interface and implementation signatures match
- [ ] Verify `supportsInterface` returns true for `IERC165`

🤖 Generated with [Claude Code](https://claude.com/claude-code)