### PR TITLE
fix: use npm install --omit=dev in slither workflow

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    env:
-      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,7 +19,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm ci --production
+        run: npm install --omit=dev
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither


### PR DESCRIPTION
## Summary
- Replace `npm ci --production` with `npm install --omit=dev` in slither workflow
- Remove `NODE_ENV: production` env var

`npm ci` fails on Linux CI runners because the macOS-generated `package-lock.json` is missing platform-specific optional dependency entries. `npm install` is tolerant of these cross-platform differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)