### PR TITLE
revert: undo slither workflow change on v5

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm install --omit=dev
+        run: npm ci --production
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither


### PR DESCRIPTION
Reverts #17. This change should only apply to v6 repos.